### PR TITLE
Don't automatically label support issues as questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bff-question.md
+++ b/.github/ISSUE_TEMPLATE/bff-question.md
@@ -2,7 +2,7 @@
 name: BFF question or bug report
 about: Question related to BFF
 title: ''
-labels: ['BFF', 'question']
+labels: ['BFF']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/identityserver-question.md
+++ b/.github/ISSUE_TEMPLATE/identityserver-question.md
@@ -2,7 +2,7 @@
 name: IdentityServer question or bug report
 about: Question related to IdentityServer
 title: ''
-labels: ['IdentityServer', 'question']
+labels: ['IdentityServer']
 assignees: ''
 
 ---


### PR DESCRIPTION
This way we can label something as question or bug or investigating or whatever as appropriate. Helps in filtering, IMO.