### PR TITLE
Template for AccessTokenManagement

### DIFF
--- a/.github/ISSUE_TEMPLATE/dam-question.md
+++ b/.github/ISSUE_TEMPLATE/dam-question.md
@@ -1,0 +1,34 @@
+---
+name: AccessTokenManagement question or bug report
+about: Question related to AccessTokenManagement
+title: ''
+labels: ['Token Management']
+assignees: ''
+
+---
+
+**Which version of Duende.AccessTokenManagement are you using?**
+
+**Which version of .NET are you using?**
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Log output/exception with stacktrace**
+
+```
+data
+```
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 * Ask a question about [IdentityServer](https://github.com/DuendeSoftware/Support/issues/new?assignees=&labels=IdentityServer&template=identityserver-question.md&title=)
 * Ask a question about [BFF](https://github.com/DuendeSoftware/Support/issues/new?assignees=&labels=BFF&template=bff-question.md&title=)
+* Ask a question about [AccessTokenManagement](https://github.com/DuendeSoftware/Support/issues/new?assignees=&labels=Token%20Management&template=dam-question.md&title=)


### PR DESCRIPTION
I was made aware that the DAM repo redirects here for questions, but there is no template option for DAM questions.